### PR TITLE
Jtarka/decimal format/large and small numbers

### DIFF
--- a/src/number/format-decimal.js
+++ b/src/number/format-decimal.js
@@ -22,10 +22,16 @@ module.exports = function(value, localeData, options) {
 	var decimalStr = null;
 
 	if (hasDecimal) {
-		// get a string of 0.xxx
-		decimalStr = '' + (Math.round((value - integerValue) * precisionScaling) / precisionScaling);
-		// the first decimal place is index 2
-		decimalStr = decimalStr.slice(2);
+		var decimalValue = Math.round( (value - integerValue) * precisionScaling) / precisionScaling;
+		if (decimalValue.toExponential() === decimalValue.toString()) {
+			// Get a string with leading zeros
+			decimalStr = formatExponentialDecimal(decimalValue);
+		} else {
+			// get a string of 0.xxx
+			decimalStr = '' + decimalValue;
+			// the first decimal place is index 2
+			decimalStr = decimalStr.slice(2);
+		}
 	} else if (options.minimumFractionDigits > 0) {
 		decimalStr = '';
 	}
@@ -48,3 +54,17 @@ module.exports = function(value, localeData, options) {
 	return ret;
 
 };
+
+function formatExponentialDecimal( value) {
+	// Get a value like "1.25e-8" and find its values
+	value = parseFloat(value).toExponential();
+
+	var pieces = value.split( 'e-' ),
+		ret = pieces[0].replace( pieces[0].charAt(1), '' ),
+		zeroCount = parseInt( pieces[1] ) - 1;
+
+	for (var i = 0; i < zeroCount; i++) {
+		ret = '0' + ret;
+	}
+	return ret;
+}

--- a/src/number/format-decimal.js
+++ b/src/number/format-decimal.js
@@ -14,7 +14,7 @@ module.exports = function formatDecimal(value, localeData, options) {
 	// round to desired precision
 	value = Math.abs(Math.round(value * precisionScaling) / precisionScaling);
 
-	var integerValue = Math.trunc( value );
+	var integerValue = Math.floor(value);
 
 	var ret = formatPositiveInteger(integerValue, localeData, options);
 
@@ -22,13 +22,15 @@ module.exports = function formatDecimal(value, localeData, options) {
 	var decimalStr = null;
 
 	if (hasDecimal) {
-		var decimalValue = Math.round( (value - integerValue) * precisionScaling) / precisionScaling;
-		if (decimalValue.toExponential() === decimalValue.toString()) {
+		var decimalValue = Math.round((value - integerValue) * precisionScaling) / precisionScaling;
+
+		// get a string of 0.xxx, or exponent of x.xe-x
+		decimalStr = '' + decimalValue;
+
+		if (decimalValue.toExponential() === decimalStr) {
 			// Get a string with leading zeros
-			decimalStr = formatExponentialDecimal(decimalValue);
+			decimalStr = formatExponentialDecimal(decimalStr);
 		} else {
-			// get a string of 0.xxx
-			decimalStr = '' + decimalValue;
 			// the first decimal place is index 2
 			decimalStr = decimalStr.slice(2);
 		}
@@ -55,13 +57,11 @@ module.exports = function formatDecimal(value, localeData, options) {
 
 };
 
-function formatExponentialDecimal( value) {
-	// Get a value like "1.25e-8" and find its values
-	value = parseFloat(value).toExponential();
-
-	var pieces = value.split( 'e-' ),
-		ret = pieces[0].replace( pieces[0].charAt(1), '' ),
-		zeroCount = parseInt( pieces[1] ) - 1;
+function formatExponentialDecimal(value) {
+	// Get a value should be like "1.25e-8"
+	var pieces = value.split('e-'),
+		ret = pieces[0].replace('.', ''),
+		zeroCount = parseInt(pieces[1]) - 1;
 
 	for (var i = 0; i < zeroCount; i++) {
 		ret = '0' + ret;

--- a/src/number/format-decimal.js
+++ b/src/number/format-decimal.js
@@ -4,7 +4,7 @@ var formatPositiveInteger = require('./format-positive-integer'),
 	validateFormatOptions = require('./validate-format-options'),
 	validateFormatValue = require('./validate-format-value');
 
-module.exports = function(value, localeData, options) {
+module.exports = function formatDecimal(value, localeData, options) {
 	value = validateFormatValue(value);
 	options = validateFormatOptions(options);
 
@@ -14,7 +14,7 @@ module.exports = function(value, localeData, options) {
 	// round to desired precision
 	value = Math.abs(Math.round(value * precisionScaling) / precisionScaling);
 
-	var integerValue = value | 0;
+	var integerValue = Math.trunc( value );
 
 	var ret = formatPositiveInteger(integerValue, localeData, options);
 

--- a/src/number/format-positive-integer.js
+++ b/src/number/format-positive-integer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function formatPositiveInteger(value, localeData/*, options*/) {
-	value = Math.trunc( value );
+	value = Math.floor(value);
 
 	var valueStr = '' + value;
 	var ret = '';

--- a/src/number/format-positive-integer.js
+++ b/src/number/format-positive-integer.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = function(value, localeData/*, options*/) {
-	value = value | 0;
+module.exports = function formatPositiveInteger(value, localeData/*, options*/) {
+	value = Math.trunc( value );
 
 	var valueStr = '' + value;
 	var ret = '';

--- a/test/number/format-decimal.js
+++ b/test/number/format-decimal.js
@@ -60,7 +60,11 @@ describe('NumberFormat', function() {
 				{val: 1.234567, min: 2, expect: '1.235'},
 				{val: 1.234567, min: 8, expect: '1.23456700'},
 				{val: 0.1234567, expect: '0.123'},
-				{val: 4, min: 2, expect: '4.00'}
+				{val: 4, min: 2, expect: '4.00'},
+				{val: 1e-9, max: 15, expect: '0.000000001'},
+				{val: -1e-9, max: 15, expect: '-0.000000001'},
+				{val: 8.256e-11, max: 15, expect: '0.00000000008256'},
+				{val: 8.256e-11, max: 12, expect: '0.000000000083'}
 			].forEach(function(input) {
 				it('should format ' + input.val + ', max:' + input.max + ', min:' + input.min, function() {
 					var options = {

--- a/test/number/format-decimal.js
+++ b/test/number/format-decimal.js
@@ -64,7 +64,11 @@ describe('NumberFormat', function() {
 				{val: 1e-9, max: 15, expect: '0.000000001'},
 				{val: -1e-9, max: 15, expect: '-0.000000001'},
 				{val: 8.256e-11, max: 15, expect: '0.00000000008256'},
-				{val: 8.256e-11, max: 12, expect: '0.000000000083'}
+				{val: 8.256e-11, max: 12, expect: '0.000000000083'},
+				{val: 1e10, expect: '10,000,000,000'},
+				{val: 6.845e13, expect: '68,450,000,000,000'},
+				{val: 12345678901.123456789, max: 3, expect: '12,345,678,901.123'},
+				{val: -12345678901.123456789, max: 3, expect: '-12,345,678,901.123'}
 			].forEach(function(input) {
 				it('should format ' + input.val + ', max:' + input.max + ', min:' + input.min, function() {
 					var options = {


### PR DESCRIPTION
**Fix formatting of really small decimals**

Small decimals, expressed in scientific/exponential notation, weren't being handled correctly and would result in totally broken results.
eg: `1e-9` would become `0.-9`
This change will put the appropriate number of zeros before the significant digits when scientific notation is detected.

**Handle numbers greater than 32-bit integers**

OR-ing the number against `0` would OR it against a 32-bit integer, causing issues with numbers longer than 32-bits.
eg: `10000000000 | 0 == 1410065408`
`Math.trunc()` simply drops the decimal from a number, which appeared to be the intention of OR-ing with 0.