### PR TITLE
Fuzzy date support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Options:
   - **shortDayOfWeek**: short weekday only. e.g. "Wed"
   - **longMonth**: long month only. e.g. "September"
   - **shortMonth**: short month only. e.g. "Sep"
+  - **fuzzy**: relative to current date eg "Just now" or "Yesterday at 1:25 PM"
 
 All the date and time formatting methods take a [JavaScript Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) as input.
 

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -13,10 +13,10 @@ const oneHour = 3600000;
 const oneHourThirtyMinutes = 5400000;
 const twoHoursThirtyMinutes = 9000000;
 
-export default function FuzzyDateFormatter(localeData, locale, timeZone) {
+export default function FuzzyDateFormatter(localeData, locale, timezone) {
 	this.format = localeData.date.formats.fuzzyFormats;
 	this.locale = locale;
-	this.timeZone = timeZone ||  new Intl.DateTimeFormat().resolvedOptions().timeZone;
+	this.timezone = timezone ||  new Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
 /*
@@ -28,14 +28,14 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const calendarDateDiff = (referenceDate - inputDate) / msPerDay;
 	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
-	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'numeric', hour12:false, timeZone: this.timeZone}).format(referenceDate).split(':'));
+	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'numeric', hour12:false, timeZone: this.timezone}).format(referenceDate).split(':'));
 	const timeZoneOffsetHours =  referenceDate.getHours() - configuredTimeZoneHours;
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
 	const yesterdayStart = new Date(yesterday).setHours(0 + timeZoneOffsetHours, 0, 0, 0);
 	const yesterdayEnd = new Date(yesterday).setHours(23 + timeZoneOffsetHours, 59, 59, 999);
-	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
-	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short', timeZone: this.timeZone }).format(new Date(inputDate));
-	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
+	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', timeZone: this.timezone }).format(new Date(inputDate));
+	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short', timeZone: this.timezone }).format(new Date(inputDate));
+	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric', timeZone: this.timezone }).format(new Date(inputDate));
 	let fuzzyDateString = '';
 
 	if (referenceDate < inputDate) {
@@ -49,7 +49,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	} else if (sameYear) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
 	} else {
-		fuzzyDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
+		fuzzyDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', timeZone: this.timezone }).format(new Date(inputDate));
 	}
 	return fuzzyDateString;
 };

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,4 +1,4 @@
-import DateTimeFormat from './format';
+import DateTimeFormat from './format.js';
 import processPattern from '../util/process-pattern.js';
 
 const _msPerDay = 86400000;

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -25,7 +25,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 
 	const referenceDate = nowDate || new Date();
 	const calendarDateDiff = (referenceDate - inputDate) / _msPerDay;
-	const calendarDaysRounded = Math.floor(calendarDateDiff);
+	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
 	const yesterdayStart = new Date(yesterday).setHours(0, 0, 0, 0);
@@ -37,11 +37,11 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 
 	if (calendarDateDiff < 0) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
-	} else if (calendarDaysRounded === 0) {
+	} else if (calendarDaysFloored === 0) {
 		fuzzyDateString = this._getStringSameDay(inputDate, referenceDate);
 	} else if (inputDate >= yesterdayStart && inputDate <= yesterdayEnd) {
 		fuzzyDateString = processPattern(this.format.yesterdayAtTime, {'{time}': time});
-	} else if (calendarDaysRounded < 3) {
+	} else if (calendarDaysFloored < 3) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': weekDay, '{time}': time});
 	} else if (sameYear) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -26,7 +26,6 @@ FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
 	} else if (calendarDateDiff >= 1 && calendarDateDiff < 3) {
 		feedbackDateString = this._getStringSomeDaysAgo(calendarDateDiff, feedbackDate);
 	} else if (sameYear) {
-		//these 2 functions give full date with time making the output wrong
 		var day = this._formatMonthDay(dateUTC);
 		var time = this._formatTime(dateUTC);
 		feedbackDateString = processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -13,9 +13,10 @@ const oneHour = 3600000;
 const oneHourThirtyMinutes = 5400000;
 const twoHoursThirtyMinutes = 9000000;
 
-export default function FuzzyDateFormatter(localeData, locale) {
+export default function FuzzyDateFormatter(localeData, locale, timeZone) {
 	this.format = localeData.date.formats.fuzzyFormats;
 	this.locale = locale;
+	this.timeZone = timeZone ||  new Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
 /*
@@ -27,12 +28,14 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const calendarDateDiff = (referenceDate - inputDate) / msPerDay;
 	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
+	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'2-digit', hour12:false, timeZone: this.timeZone}).format(referenceDate));
+	const timeZoneOffsetHours =  referenceDate.getHours() - configuredTimeZoneHours;
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
-	const yesterdayStart = new Date(yesterday).setHours(0, 0, 0, 0);
-	const yesterdayEnd = new Date(yesterday).setHours(23, 59, 59, 999);
-	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(inputDate));
-	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(inputDate));
-	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
+	const yesterdayStart = new Date(yesterday).setHours(0 + timeZoneOffsetHours, 0, 0, 0);
+	const yesterdayEnd = new Date(yesterday).setHours(23 + timeZoneOffsetHours, 59, 59, 999);
+	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
+	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short', timeZone: this.timeZone }).format(new Date(inputDate));
+	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
 	let fuzzyDateString = '';
 
 	if (referenceDate < inputDate) {

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -35,7 +35,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
 	let fuzzyDateString = '';
 
-	if (calendarDateDiff < 0) {
+	if (referenceDate < inputDate) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
 	} else if (calendarDaysFloored === 0) {
 		fuzzyDateString = this._getStringSameDay(inputDate, referenceDate);

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -49,7 +49,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	} else if (sameYear) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
 	} else {
-		fuzzyDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
+		fuzzyDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', timeZone: this.timeZone }).format(new Date(inputDate));
 	}
 	return fuzzyDateString;
 };

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,0 +1,134 @@
+import { DateTimeFormat } from './format';
+import processPattern from '../util/process-pattern.js';
+
+const _msPerDay = 86400000;
+const _msPerSecond = 1000;
+const _secondsPerMinute = 60;
+
+export default function FuzzyDateFormatter(localeData, locale) {
+	this.format = localeData.date.formats.fuzzyFormats;
+	this.locale = locale;
+}
+
+/*
+* Returns the fuzzy date string as determined by difference between now and date
+*/
+FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
+
+	var referenceDate = new Date();
+	var feedbackDate = new Date(dateUTC);
+	var calendarDateDiff = this._fuzzyDates_getDateDiffInCalendarDays(feedbackDate, referenceDate);
+	var sameYear = referenceDate.getYear() === feedbackDate.getYear();
+
+	var feedbackDateString = '';
+
+	if (calendarDateDiff === 0) {
+		feedbackDateString = this._getStringSameDay(feedbackDate, referenceDate);
+	} else if (calendarDateDiff >= 1 && calendarDateDiff < 3) {
+		feedbackDateString = this._getStringSomeDaysAgo(calendarDateDiff, feedbackDate);
+	} else if (sameYear) {
+		var day = this._formatMonthDay(dateUTC);
+		var time = this._formatTime(dateUTC);
+		feedbackDateString = processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});
+	} else {
+		feedbackDateString = new DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(dateUTC));
+	}
+	return feedbackDateString;
+};
+
+/*
+* Returns date as proper string for being same day
+* e.g., "Just now", "1 minute ago", "2 minutes ago", "10 minutes ago", "1 hour ago", "2 hours ago"
+*/
+FuzzyDateFormatter.prototype._getStringSameDay = function(dateUTC, referenceDate) {
+	var timeDiff = this._getDateDiffInSeconds(dateUTC, referenceDate);
+
+	var oneMinute = 60;
+	var oneHour = 60 * oneMinute;
+
+	var feedbackDateString = '';
+
+	if (timeDiff < this._minutesInSeconds(.5)) {
+		feedbackDateString = this.format.justNow;
+	} else if (timeDiff < this._minutesInSeconds(1.5)) {
+		feedbackDateString = this.format.oneMinuteAgo;
+	} else if (timeDiff < this._minutesInSeconds(2.5)) {
+		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': 2});
+	} else if (timeDiff < this._minutesInSeconds(45)) {
+		var minutesRounded = Math.round(timeDiff % oneHour / oneMinute);
+		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': minutesRounded});
+	} else {
+		if (timeDiff < this._hoursInSeconds(1.5)) {
+			feedbackDateString = this.format.oneHourAgo;
+		} else if (timeDiff < this._hoursInSeconds(2.5)) {
+			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': 2});
+		} else {
+			var hoursRounded = Math.round(timeDiff % (24 * oneHour) / oneHour);
+			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': hoursRounded});
+		}
+	}
+	return feedbackDateString;
+};
+
+/*
+* Returns date as proper string for being x days ago (e.g., Yesterday at 4:00 PM or Mon at 4:00 PM)
+*/
+FuzzyDateFormatter.prototype._getStringSomeDaysAgo = function(calendarDateDiff, dateUTC) {
+	var time = this._formatTime(dateUTC);
+	if (calendarDateDiff === 1) {
+		return processPattern(this.format.yesterdayAtTime, {'{time}': time});
+	} else {
+		var day = this._formatWeekday(dateUTC);
+		return processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});
+	}
+};
+
+/*
+* Returns the number of calendar days between the given date and now.
+*/
+FuzzyDateFormatter.prototype._fuzzyDates_getDateDiffInCalendarDays = function(feedbackDate, referenceDate) {
+	return Math.floor((referenceDate - feedbackDate) / _msPerDay);
+};
+
+/*
+* Returns the number of seconds between the given date and now.
+*/
+FuzzyDateFormatter.prototype._getDateDiffInSeconds = function(feedbackDate, referenceDate) {
+	return Math.floor((referenceDate.getTime() - feedbackDate.getTime()) / _msPerSecond);
+};
+
+/*
+* Formats weekday (e.g., Mon) in locale
+*/
+FuzzyDateFormatter.prototype._formatWeekday = function(date) {
+	return new DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(date));
+};
+
+/*
+* Formats time (e.g., 2:38 PM) in locale
+*/
+FuzzyDateFormatter.prototype._formatTime = function(date) {
+	return new DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(date));
+};
+
+/*
+* Formats month and day (e.g., December 5) in locale
+*/
+FuzzyDateFormatter.prototype._formatMonthDay = function(date) {
+	return new DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(date));
+};
+
+/*
+* Returns the number of minutes in seconds
+*/
+FuzzyDateFormatter.prototype._minutesInSeconds = function(mins) {
+	return mins * _secondsPerMinute;
+};
+
+/*
+* Returns the number of hours in seconds
+*/
+FuzzyDateFormatter.prototype._hoursInSeconds = function(hours) {
+	var minutesPerHour = 60;
+	return hours * minutesPerHour * _secondsPerMinute;
+};

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,4 +1,3 @@
-import DateTimeFormat from './format.js';
 import processPattern from '../util/process-pattern.js';
 
 const _msPerDay = 86400000;
@@ -32,7 +31,7 @@ FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
 		var time = this._formatTime(dateUTC);
 		feedbackDateString = processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});
 	} else {
-		feedbackDateString = new DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(dateUTC));
+		feedbackDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(dateUTC));
 	}
 	return feedbackDateString;
 };
@@ -102,21 +101,21 @@ FuzzyDateFormatter.prototype._getDateDiffInSeconds = function(feedbackDate, refe
 * Formats weekday (e.g., Mon) in locale
 */
 FuzzyDateFormatter.prototype._formatWeekday = function(date) {
-	return new DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(date));
+	return new Intl.DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(date));
 };
 
 /*
 * Formats time (e.g., 2:38 PM) in locale
 */
 FuzzyDateFormatter.prototype._formatTime = function(date) {
-	return new DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(date));
+	return new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(date));
 };
 
 /*
 * Formats month and day (e.g., December 5) in locale
 */
 FuzzyDateFormatter.prototype._formatMonthDay = function(date) {
-	return new DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(date));
+	return new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(date));
 };
 
 /*

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,8 +1,17 @@
 import processPattern from '../util/process-pattern.js';
 
 const _msPerDay = 86400000;
-const _msPerSecond = 1000;
-const _secondsPerMinute = 60;
+
+const thirtySeconds = 30000;
+const ninetySeconds = 90000;
+
+const oneMinute = 60000;
+const twoAndAHalfMinutes = 150000;
+const fortyFiveMinutes = 2700000;
+
+const oneHour = 3600000;
+const oneHourThirtyMinutes = 5400000;
+const twoHoursThirtyMinutes = 9000000;
 
 export default function FuzzyDateFormatter(localeData, locale) {
 	this.format = localeData.date.formats.fuzzyFormats;
@@ -12,27 +21,31 @@ export default function FuzzyDateFormatter(localeData, locale) {
 /*
 * Returns the fuzzy date string as determined by difference between now and date
 */
-FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
+FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 
-	var referenceDate = new Date();
-	var feedbackDate = new Date(dateUTC);
-	var calendarDateDiff = this._fuzzyDates_getDateDiffInCalendarDays(feedbackDate, referenceDate);
-	var sameYear = referenceDate.getYear() === feedbackDate.getYear();
+	const referenceDate = nowDate || new Date();
+	const calendarDateDiff = (referenceDate - inputDate) / _msPerDay;
+	const calendarDaysRounded = Math.floor(calendarDateDiff);
+	const sameYear = referenceDate.getYear() === inputDate.getYear();
+	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(inputDate));
+	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(inputDate));
+	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
+	let fuzzyDateString = '';
 
-	var feedbackDateString = '';
-
-	if (calendarDateDiff === 0) {
-		feedbackDateString = this._getStringSameDay(feedbackDate, referenceDate);
-	} else if (calendarDateDiff >= 1 && calendarDateDiff < 3) {
-		feedbackDateString = this._getStringSomeDaysAgo(calendarDateDiff, feedbackDate);
+	if (calendarDateDiff < 0) {
+		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
+	} else if (calendarDaysRounded === 0) {
+		fuzzyDateString = this._getStringSameDay(inputDate, referenceDate);
+	} else if (calendarDaysRounded === 1 && (referenceDate.getDay() - inputDate.getDay()) < 2) {
+		fuzzyDateString = processPattern(this.format.yesterdayAtTime, {'{time}': time});
+	} else if (calendarDaysRounded < 3) {
+		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': weekDay, '{time}': time});
 	} else if (sameYear) {
-		var day = this._formatMonthDay(dateUTC);
-		var time = this._formatTime(dateUTC);
-		feedbackDateString = processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});
+		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
 	} else {
-		feedbackDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(dateUTC));
+		fuzzyDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
 	}
-	return feedbackDateString;
+	return fuzzyDateString;
 };
 
 /*
@@ -40,94 +53,27 @@ FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
 * e.g., "Just now", "1 minute ago", "2 minutes ago", "10 minutes ago", "1 hour ago", "2 hours ago"
 */
 FuzzyDateFormatter.prototype._getStringSameDay = function(dateUTC, referenceDate) {
-	var timeDiff = this._getDateDiffInSeconds(dateUTC, referenceDate);
+	const timeDiff = Math.floor(referenceDate.getTime() - dateUTC.getTime());
 
-	var oneMinute = 60;
-	var oneHour = 60 * oneMinute;
-
-	var feedbackDateString = '';
-
-	if (timeDiff < this._minutesInSeconds(.5)) {
+	let feedbackDateString = '';
+	if (timeDiff < thirtySeconds) {
 		feedbackDateString = this.format.justNow;
-	} else if (timeDiff < this._minutesInSeconds(1.5)) {
+	} else if (timeDiff < ninetySeconds) {
 		feedbackDateString = this.format.oneMinuteAgo;
-	} else if (timeDiff < this._minutesInSeconds(2.5)) {
+	} else if (timeDiff < twoAndAHalfMinutes) {
 		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': 2});
-	} else if (timeDiff < this._minutesInSeconds(45)) {
-		var minutesRounded = Math.round(timeDiff % oneHour / oneMinute);
+	} else if (timeDiff < fortyFiveMinutes) {
+		const minutesRounded = Math.round(timeDiff % oneHour / oneMinute);
 		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': minutesRounded});
 	} else {
-		if (timeDiff < this._hoursInSeconds(1.5)) {
+		if (timeDiff < oneHourThirtyMinutes) {
 			feedbackDateString = this.format.oneHourAgo;
-		} else if (timeDiff < this._hoursInSeconds(2.5)) {
+		} else if (timeDiff < twoHoursThirtyMinutes) {
 			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': 2});
 		} else {
-			var hoursRounded = Math.round(timeDiff % (24 * oneHour) / oneHour);
+			const hoursRounded = Math.round(timeDiff % (24 * oneHour) / oneHour);
 			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': hoursRounded});
 		}
 	}
 	return feedbackDateString;
-};
-
-/*
-* Returns date as proper string for being x days ago (e.g., Yesterday at 4:00 PM or Mon at 4:00 PM)
-*/
-FuzzyDateFormatter.prototype._getStringSomeDaysAgo = function(calendarDateDiff, dateUTC) {
-	var time = this._formatTime(dateUTC);
-	if (calendarDateDiff === 1) {
-		return processPattern(this.format.yesterdayAtTime, {'{time}': time});
-	} else {
-		var day = this._formatWeekday(dateUTC);
-		return processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});
-	}
-};
-
-/*
-* Returns the number of calendar days between the given date and now.
-*/
-FuzzyDateFormatter.prototype._fuzzyDates_getDateDiffInCalendarDays = function(feedbackDate, referenceDate) {
-	return Math.floor((referenceDate - feedbackDate) / _msPerDay);
-};
-
-/*
-* Returns the number of seconds between the given date and now.
-*/
-FuzzyDateFormatter.prototype._getDateDiffInSeconds = function(feedbackDate, referenceDate) {
-	return Math.floor((referenceDate.getTime() - feedbackDate.getTime()) / _msPerSecond);
-};
-
-/*
-* Formats weekday (e.g., Mon) in locale
-*/
-FuzzyDateFormatter.prototype._formatWeekday = function(date) {
-	return new Intl.DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(date));
-};
-
-/*
-* Formats time (e.g., 2:38 PM) in locale
-*/
-FuzzyDateFormatter.prototype._formatTime = function(date) {
-	return new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(date));
-};
-
-/*
-* Formats month and day (e.g., December 5) in locale
-*/
-FuzzyDateFormatter.prototype._formatMonthDay = function(date) {
-	return new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(date));
-};
-
-/*
-* Returns the number of minutes in seconds
-*/
-FuzzyDateFormatter.prototype._minutesInSeconds = function(mins) {
-	return mins * _secondsPerMinute;
-};
-
-/*
-* Returns the number of hours in seconds
-*/
-FuzzyDateFormatter.prototype._hoursInSeconds = function(hours) {
-	var minutesPerHour = 60;
-	return hours * minutesPerHour * _secondsPerMinute;
 };

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,4 +1,4 @@
-import { DateTimeFormat } from './format';
+import DateTimeFormat from './format';
 import processPattern from '../util/process-pattern.js';
 
 const _msPerDay = 86400000;
@@ -27,6 +27,7 @@ FuzzyDateFormatter.prototype.getDateString = function(dateUTC)  {
 	} else if (calendarDateDiff >= 1 && calendarDateDiff < 3) {
 		feedbackDateString = this._getStringSomeDaysAgo(calendarDateDiff, feedbackDate);
 	} else if (sameYear) {
+		//these 2 functions give full date with time making the output wrong
 		var day = this._formatMonthDay(dateUTC);
 		var time = this._formatTime(dateUTC);
 		feedbackDateString = processPattern(this.format.dayAtTime, {'{day}': day, '{time}': time});

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -27,6 +27,9 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const calendarDateDiff = (referenceDate - inputDate) / _msPerDay;
 	const calendarDaysRounded = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
+	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
+	const yesterdayStart = new Date(yesterday).setHours(0, 0, 0, 0);
+	const yesterdayEnd = new Date(yesterday).setHours(23, 59, 59, 999);
 	const monthDay = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(inputDate));
 	const weekDay = new Intl.DateTimeFormat(this.locale, { weekday: 'short' }).format(new Date(inputDate));
 	const time = new Intl.DateTimeFormat(this.locale, { hour: 'numeric', minute: 'numeric' }).format(new Date(inputDate));
@@ -36,7 +39,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': monthDay, '{time}': time});
 	} else if (calendarDaysRounded === 0) {
 		fuzzyDateString = this._getStringSameDay(inputDate, referenceDate);
-	} else if (calendarDaysRounded === 1 && (referenceDate.getDay() - inputDate.getDay()) < 2) {
+	} else if (inputDate >= yesterdayStart && inputDate <= yesterdayEnd) {
 		fuzzyDateString = processPattern(this.format.yesterdayAtTime, {'{time}': time});
 	} else if (calendarDaysRounded < 3) {
 		fuzzyDateString = processPattern(this.format.dayAtTime, {'{day}': weekDay, '{time}': time});

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -28,7 +28,7 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const calendarDateDiff = (referenceDate - inputDate) / msPerDay;
 	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
-	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'2-digit', hour12:false, timeZone: this.timeZone}).format(referenceDate));
+	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'numeric', hour12:false, timeZone: this.timeZone}).format(referenceDate).split(':'));
 	const timeZoneOffsetHours =  referenceDate.getHours() - configuredTimeZoneHours;
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
 	const yesterdayStart = new Date(yesterday).setHours(0 + timeZoneOffsetHours, 0, 0, 0);

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -28,7 +28,8 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 	const calendarDateDiff = (referenceDate - inputDate) / msPerDay;
 	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
-	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'numeric', hour12:false, timeZone: this.timezone}).format(referenceDate).split(':'));
+	//ie 11 injects non ascii characters into the hours returned.  need to use match
+	const configuredTimeZoneHours = parseInt(new Intl.DateTimeFormat(this.locale, {hour:'numeric', hour12:false, timeZone: this.timezone}).format(referenceDate).match(/\d+/g)[0]);
 	const timeZoneOffsetHours =  referenceDate.getHours() - configuredTimeZoneHours;
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);
 	const yesterdayStart = new Date(yesterday).setHours(0 + timeZoneOffsetHours, 0, 0, 0);

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -55,28 +55,28 @@ FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 * Returns date as proper string for being same day
 * e.g., "Just now", "1 minute ago", "2 minutes ago", "10 minutes ago", "1 hour ago", "2 hours ago"
 */
-FuzzyDateFormatter.prototype._getStringSameDay = function(dateUTC, referenceDate) {
-	const timeDiff = Math.floor(referenceDate.getTime() - dateUTC.getTime());
+FuzzyDateFormatter.prototype._getStringSameDay = function(inputDate, referenceDate) {
+	const timeDiff = Math.floor(referenceDate.getTime() - inputDate.getTime());
 
-	let feedbackDateString = '';
+	let sameDayDateString = '';
 	if (timeDiff < thirtySeconds) {
-		feedbackDateString = this.format.justNow;
+		sameDayDateString = this.format.justNow;
 	} else if (timeDiff < ninetySeconds) {
-		feedbackDateString = this.format.oneMinuteAgo;
+		sameDayDateString = this.format.oneMinuteAgo;
 	} else if (timeDiff < twoAndAHalfMinutes) {
-		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': 2});
+		sameDayDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': 2});
 	} else if (timeDiff < fortyFiveMinutes) {
 		const minutesRounded = Math.round(timeDiff % oneHour / oneMinute);
-		feedbackDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': minutesRounded});
+		sameDayDateString = processPattern(this.format.minutesAgo, {'{numMinutes}': minutesRounded});
 	} else {
 		if (timeDiff < oneHourThirtyMinutes) {
-			feedbackDateString = this.format.oneHourAgo;
+			sameDayDateString = this.format.oneHourAgo;
 		} else if (timeDiff < twoHoursThirtyMinutes) {
-			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': 2});
+			sameDayDateString = processPattern(this.format.hoursAgo, {'{numHours}': 2});
 		} else {
 			const hoursRounded = Math.round(timeDiff % (24 * oneHour) / oneHour);
-			feedbackDateString = processPattern(this.format.hoursAgo, {'{numHours}': hoursRounded});
+			sameDayDateString = processPattern(this.format.hoursAgo, {'{numHours}': hoursRounded});
 		}
 	}
-	return feedbackDateString;
+	return sameDayDateString;
 };

--- a/src/date-time/format-fuzzy-date.js
+++ b/src/date-time/format-fuzzy-date.js
@@ -1,6 +1,6 @@
 import processPattern from '../util/process-pattern.js';
 
-const _msPerDay = 86400000;
+const msPerDay = 86400000;
 
 const thirtySeconds = 30000;
 const ninetySeconds = 90000;
@@ -24,7 +24,7 @@ export default function FuzzyDateFormatter(localeData, locale) {
 FuzzyDateFormatter.prototype.getDateString = function(inputDate, nowDate)  {
 
 	const referenceDate = nowDate || new Date();
-	const calendarDateDiff = (referenceDate - inputDate) / _msPerDay;
+	const calendarDateDiff = (referenceDate - inputDate) / msPerDay;
 	const calendarDaysFloored = Math.floor(calendarDateDiff);
 	const sameYear = referenceDate.getYear() === inputDate.getYear();
 	const yesterday = new Date(referenceDate).setDate(referenceDate.getDate() - 1);

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -1,5 +1,6 @@
 import formatTime from './format-time.js';
 import formatDate from './format-date.js';
+import formatFuzzyDate from './format-fuzzy-date.js';
 import localeProvider from '../locale-provider.js';
 
 export default function DateTimeFormat(locale, options) {
@@ -38,4 +39,7 @@ DateTimeFormat.prototype.formatDate = function(date) {
 };
 DateTimeFormat.prototype.formatTime = function(date) {
 	return formatTime(date, this.localeData, this.options);
+};
+DateTimeFormat.prototype.formatFuzzyDate = function(date) {
+	return new formatFuzzyDate(this.localeData, this.options.locale).getDateString(date);
 };

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -7,7 +7,7 @@ export default function DateTimeFormat(locale, options) {
 	options = options || {};
 	this.options = options;
 	this.localeData = localeProvider(locale, options.locale);
-	this.formatFuzzyDate = new formatFuzzyDate(this.localeData, this.options.locale);
+	this._fuzzyDateFormatter = new formatFuzzyDate(this.localeData, this.options.locale);
 }
 DateTimeFormat.prototype.format = function(date) {
 	var format = this.options.format || 'short';
@@ -42,5 +42,5 @@ DateTimeFormat.prototype.formatTime = function(date) {
 	return formatTime(date, this.localeData, this.options);
 };
 DateTimeFormat.prototype.formatFuzzyDate = function(date) {
-	return this.formatFuzzyDate.getDateString(date);
+	return this._fuzzyDateFormatter.getDateString(date);
 };

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -32,7 +32,7 @@ DateTimeFormat.prototype.format = function(date) {
 			format = 'MMM';
 			break;
 	}
-	var value = formatDate(date, this.localeData, {format: format});
+	var value = format === 'fuzzy' ? this._fuzzyDateFormatter.getDateString(date) : formatDate(date, this.localeData, {format: format});
 	return value;
 };
 DateTimeFormat.prototype.formatDate = function(date) {

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -41,6 +41,6 @@ DateTimeFormat.prototype.formatDate = function(date) {
 DateTimeFormat.prototype.formatTime = function(date) {
 	return formatTime(date, this.localeData, this.options);
 };
-DateTimeFormat.prototype.formatFuzzyDate = function(date) {
-	return this._fuzzyDateFormatter.getDateString(date);
+DateTimeFormat.prototype.formatFuzzyDate = function(date, now) {
+	return this._fuzzyDateFormatter.getDateString(date, now);
 };

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -7,7 +7,7 @@ export default function DateTimeFormat(locale, options) {
 	options = options || {};
 	this.options = options;
 	this.localeData = localeProvider(locale, options.locale);
-	this._fuzzyDateFormatter = new formatFuzzyDate(this.localeData, this.options.locale, this.options.timeZone);
+	this._fuzzyDateFormatter = new formatFuzzyDate(this.localeData, this.options.locale, this.options.timezoneidentifier);
 }
 DateTimeFormat.prototype.format = function(date) {
 	var format = this.options.format || 'short';

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -7,6 +7,7 @@ export default function DateTimeFormat(locale, options) {
 	options = options || {};
 	this.options = options;
 	this.localeData = localeProvider(locale, options.locale);
+	this.formatFuzzyDate = new formatFuzzyDate(this.localeData, this.options.locale);
 }
 DateTimeFormat.prototype.format = function(date) {
 	var format = this.options.format || 'short';
@@ -41,5 +42,5 @@ DateTimeFormat.prototype.formatTime = function(date) {
 	return formatTime(date, this.localeData, this.options);
 };
 DateTimeFormat.prototype.formatFuzzyDate = function(date) {
-	return new formatFuzzyDate(this.localeData, this.options.locale).getDateString(date);
+	return this.formatFuzzyDate.getDateString(date);
 };

--- a/src/date-time/format.js
+++ b/src/date-time/format.js
@@ -7,7 +7,7 @@ export default function DateTimeFormat(locale, options) {
 	options = options || {};
 	this.options = options;
 	this.localeData = localeProvider(locale, options.locale);
-	this._fuzzyDateFormatter = new formatFuzzyDate(this.localeData, this.options.locale);
+	this._fuzzyDateFormatter = new formatFuzzyDate(this.localeData, this.options.locale, this.options.timeZone);
 }
 DateTimeFormat.prototype.format = function(date) {
 	var format = this.options.format || 'short';

--- a/src/locale-data/ar-SA.js
+++ b/src/locale-data/ar-SA.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM, yyyy',
 				'monthDay': 'd MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'أمس عند الساعة {time}',
+				'dayAtTime': '{day} عند الساعة {time}',
+				'justNow': 'الآن',
+				'oneMinuteAgo': 'منذ دقيقة واحدة',
+				'minutesAgo': 'منذ {numMinutes} من الدقائق',
+				'oneHourAgo': 'منذ ساعة واحدة',
+				'hoursAgo': 'منذ {numHours} من الساعات',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/ar.js
+++ b/src/locale-data/ar.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM, yyyy',
 				'monthDay': 'd MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'أمس عند الساعة {time}',
+				'dayAtTime': '{day} عند الساعة {time}',
+				'justNow': 'الآن',
+				'oneMinuteAgo': 'منذ دقيقة واحدة',
+				'minutesAgo': 'منذ {numMinutes} من الدقائق',
+				'oneHourAgo': 'منذ ساعة واحدة',
+				'hoursAgo': 'منذ {numHours} من الساعات',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/en-CA.js
+++ b/src/locale-data/en-CA.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Yesterday at {time}',
+				'dayAtTime': '{day} at {time}',
+				'justNow': 'Just now',
+				'oneMinuteAgo': '1 minute ago',
+				'minutesAgo': '{numMinutes} minutes ago',
+				'oneHourAgo': '1 hour ago',
+				'hoursAgo': '{numHours} hours ago',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/en-GB.js
+++ b/src/locale-data/en-GB.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Yesterday at {time}',
+				'dayAtTime': '{day} at {time}',
+				'justNow': 'Just now',
+				'oneMinuteAgo': '1 minute ago',
+				'minutesAgo': '{numMinutes} minutes ago',
+				'oneHourAgo': '1 hour ago',
+				'hoursAgo': '{numHours} hours ago',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/en-US.js
+++ b/src/locale-data/en-US.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Yesterday at {time}',
+				'dayAtTime': '{day} at {time}',
+				'justNow': 'Just now',
+				'oneMinuteAgo': '1 minute ago',
+				'minutesAgo': '{numMinutes} minutes ago',
+				'oneHourAgo': '1 hour ago',
+				'hoursAgo': '{numHours} hours ago',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/en.js
+++ b/src/locale-data/en.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Yesterday at {time}',
+				'dayAtTime': '{day} at {time}',
+				'justNow': 'Just now',
+				'oneMinuteAgo': '1 minute ago',
+				'minutesAgo': '{numMinutes} minutes ago',
+				'oneHourAgo': '1 hour ago',
+				'hoursAgo': '{numHours} hours ago',
+			},
 			'timeFormats': {
 				'full': 'h:mm tt ZZZ',
 				'medium': 'h:mm tt',

--- a/src/locale-data/es-MX.js
+++ b/src/locale-data/es-MX.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'd\' de \'MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Ayer a las {time}',
+				'dayAtTime': '{day} a las {time}',
+				'justNow': 'Recién',
+				'oneMinuteAgo': 'Hace un minuto',
+				'minutesAgo': 'Hace {numMinutes} minuto(s)',
+				'oneHourAgo': 'Hace una hora',
+				'hoursAgo': 'Hace {numHours} horas',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/es.js
+++ b/src/locale-data/es.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'd\' de \'MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Ayer a las {time}',
+				'dayAtTime': '{day} a las {time}',
+				'justNow': 'Recién',
+				'oneMinuteAgo': 'Hace un minuto',
+				'minutesAgo': 'Hace {numMinutes} minuto(s)',
+				'oneHourAgo': 'Hace una hora',
+				'hoursAgo': 'Hace {numHours} horas',
+			},
 			'timeFormats': {
 				'full': 'H:mm ZZZ',
 				'medium': 'H:mm',

--- a/src/locale-data/fr-CA.js
+++ b/src/locale-data/fr-CA.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Hier à {time}',
+				'dayAtTime': '{day} à {time}',
+				'justNow': 'En ce moment',
+				'oneMinuteAgo': 'il y a 1 minute',
+				'minutesAgo': 'il y a {numMinutes} minutes',
+				'oneHourAgo': 'il y a 1 heure',
+				'hoursAgo': 'il y a {numHours} heures',
+			},
 			'timeFormats': {
 				'full': 'HH\' h \'mm ZZZ',
 				'medium': 'HH\' h \'mm',

--- a/src/locale-data/fr.js
+++ b/src/locale-data/fr.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Hier à {time}',
+				'dayAtTime': '{day} à {time}',
+				'justNow': 'En ce moment',
+				'oneMinuteAgo': 'il y a 1 minute',
+				'minutesAgo': 'il y a {numMinutes} minutes',
+				'oneHourAgo': 'il y a 1 heure',
+				'hoursAgo': 'il y a {numHours} heures',
+			},
 			'timeFormats': {
 				'full': 'HH\' h \'mm ZZZ',
 				'medium': 'HH\' h \'mm',

--- a/src/locale-data/ja.js
+++ b/src/locale-data/ja.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy年M月',
 				'monthDay': 'M月d日'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': '昨日 {time} 時',
+				'dayAtTime': '{day} 日 {time} 時',
+				'justNow': '今',
+				'oneMinuteAgo': '1 分前',
+				'minutesAgo': '{numMinutes} 分前',
+				'oneHourAgo': '1 時間前',
+				'hoursAgo': '{numHours} 時間前',
+			},
 			'timeFormats': {
 				'full': 'H:mm ZZZ',
 				'medium': 'H:mm',

--- a/src/locale-data/ko-KR.js
+++ b/src/locale-data/ko-KR.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy년 M월',
 				'monthDay': 'M월 d일'
 			},
+			'fuzzyFormats':{
+				'yesterdayAtTime': '어제 {time}',
+				'dayAtTime': '{day}, {time}',
+				'justNow': '방금',
+				'oneMinuteAgo': '1분 전',
+				'minutesAgo': '{numMinutes}분 전',
+				'oneHourAgo': '1시간 전',
+				'hoursAgo': '{numHours}시간 전',
+			},
 			'timeFormats': {
 				'full': 'tt h:mm ZZZ',
 				'medium': 'tt h:mm',

--- a/src/locale-data/ko.js
+++ b/src/locale-data/ko.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy년 M월',
 				'monthDay': 'M월 d일'
 			},
+			'fuzzyFormats':{
+				'yesterdayAtTime': '어제 {time}',
+				'dayAtTime': '{day}, {time}',
+				'justNow': '방금',
+				'oneMinuteAgo': '1분 전',
+				'minutesAgo': '{numMinutes}분 전',
+				'oneHourAgo': '1시간 전',
+				'hoursAgo': '{numHours}시간 전',
+			},
 			'timeFormats': {
 				'full': 'tt h:mm ZZZ',
 				'medium': 'tt h:mm',

--- a/src/locale-data/pt-BR.js
+++ b/src/locale-data/pt-BR.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Ontem às {time}',
+				'dayAtTime': '{day} às {time}',
+				'justNow': 'Agora',
+				'oneMinuteAgo': '1 minuto atrás',
+				'minutesAgo': '{numMinutes} minutos atrás',
+				'oneHourAgo': '1 hora atrás',
+				'hoursAgo': '{numHours} horas atrás',
+			},
 			'timeFormats': {
 				'full': 'H:mm ZZZ',
 				'medium': 'H:mm',

--- a/src/locale-data/pt.js
+++ b/src/locale-data/pt.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Ontem às {time}',
+				'dayAtTime': '{day} às {time}',
+				'justNow': 'Agora',
+				'oneMinuteAgo': '1 minuto atrás',
+				'minutesAgo': '{numMinutes} minutos atrás',
+				'oneHourAgo': '1 hora atrás',
+				'hoursAgo': '{numHours} horas atrás',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/sv-SE.js
+++ b/src/locale-data/sv-SE.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Igår kl. {time}',
+				'dayAtTime': '{day} kl. {time}',
+				'justNow': 'Just nu',
+				'oneMinuteAgo': '1 minut sedan',
+				'minutesAgo': '{numMinutes} minuter sedan',
+				'oneHourAgo': '1 timme sedan',
+				'hoursAgo': '{numHours} timmar sedan',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/sv.js
+++ b/src/locale-data/sv.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'MMMM d'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Igår kl. {time}',
+				'dayAtTime': '{day} kl. {time}',
+				'justNow': 'Just nu',
+				'oneMinuteAgo': '1 minut sedan',
+				'minutesAgo': '{numMinutes} minuter sedan',
+				'oneHourAgo': '1 timme sedan',
+				'hoursAgo': '{numHours} timmar sedan',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/tr-TR.js
+++ b/src/locale-data/tr-TR.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'dd MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Dün şu saatte: {time}',
+				'dayAtTime': '{day} günü şu saatte: {time}',
+				'justNow': 'Şimdi',
+				'oneMinuteAgo': '1 dakika önce',
+				'minutesAgo': '{numMinutes} dakika önce',
+				'oneHourAgo': '1 saat önce',
+				'hoursAgo': '{numHours} saat önce',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/tr.js
+++ b/src/locale-data/tr.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'MMMM yyyy',
 				'monthDay': 'dd MMMM'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': 'Dün şu saatte: {time}',
+				'dayAtTime': '{day} günü şu saatte: {time}',
+				'justNow': 'Şimdi',
+				'oneMinuteAgo': '1 dakika önce',
+				'minutesAgo': '{numMinutes} dakika önce',
+				'oneHourAgo': '1 saat önce',
+				'hoursAgo': '{numHours} saat önce',
+			},
 			'timeFormats': {
 				'full': 'HH:mm ZZZ',
 				'medium': 'HH:mm',

--- a/src/locale-data/zh-CN.js
+++ b/src/locale-data/zh-CN.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy年M月',
 				'monthDay': 'M月d日'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': '昨天 {time}',
+				'dayAtTime': '{day} 的 {time}',
+				'justNow': '刚刚',
+				'oneMinuteAgo': '1 分钟前',
+				'minutesAgo': '{numMinutes} 分钟前',
+				'oneHourAgo': '1 小时前',
+				'hoursAgo': '{numHours} 小时前',
+			},
 			'timeFormats': {
 				'full': 'ZZZ H:mm',
 				'medium': 'H:mm',

--- a/src/locale-data/zh-TW.js
+++ b/src/locale-data/zh-TW.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy年M月',
 				'monthDay': 'M月d日'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': '昨天在 {time}',
+				'dayAtTime': '{day} 在 {time}',
+				'justNow': '現在',
+				'oneMinuteAgo': '1 分鐘前',
+				'minutesAgo': '{numMinutes} 分鐘前',
+				'oneHourAgo': '1 小時前',
+				'hoursAgo': '{numHours} 小時前',
+			},
 			'timeFormats': {
 				'full': 'tt hh:mm ZZZ',
 				'medium': 'tt hh:mm',

--- a/src/locale-data/zh.js
+++ b/src/locale-data/zh.js
@@ -10,6 +10,15 @@ export default {
 				'monthYear': 'yyyy年M月',
 				'monthDay': 'M月d日'
 			},
+			'fuzzyFormats': {
+				'yesterdayAtTime': '昨天 {time}',
+				'dayAtTime': '{day} 的 {time}',
+				'justNow': '刚刚',
+				'oneMinuteAgo': '1 分钟前',
+				'minutesAgo': '{numMinutes} 分钟前',
+				'oneHourAgo': '1 小时前',
+				'hoursAgo': '{numHours} 小时前',
+			},
 			'timeFormats': {
 				'full': 'ZZZ H:mm',
 				'medium': 'H:mm',

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -1,6 +1,6 @@
-import FuzzyDate from '../../src/date-time/format-fuzzy-date';
-import DateTimeFormat from '../../src/date-time/format';
-import en from '../../src/locale-data/en';
+import FuzzyDate from '../../src/date-time/format-fuzzy-date.js';
+import DateTimeFormat from '../../src/date-time/format.js';
+import en from '../../src/locale-data/en.js';
 
 var expect = chai.expect;
 

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -1,29 +1,23 @@
-import FuzzyDate from '../../src/date-time/format-fuzzy-date.js';
 import DateTimeFormat from '../../src/date-time/format.js';
-import en from '../../src/locale-data/en.js';
 
 var expect = chai.expect;
 
-describe('formatfuzzydate', function() {
-	var component;
+describe('DateTimeFormat', function() {
+	var component = new DateTimeFormat('en-US');
 
-	beforeEach(function() {
-		component = new FuzzyDate(en, 'en');
-	});
-
-	describe('getDateString', function() {
+	describe('formatFuzzyDate', function() {
 		it('should return "just now" if feedback posted recently', function() {
 			var date = new Date();
-			var feedbackString = component.getDateString(date);
+			var feedbackString = component.formatFuzzyDate(date);
 			expect(feedbackString).to.equal('Just now');
 		});
 
 		it('should return date time if feedback posted in the future', function() {
 			var date = new Date();
 			date.setSeconds(date.getSeconds() + 60);
-			var feedbackString = component.getDateString(date);
-			var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-			var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
+			var feedbackString = component.formatFuzzyDate(date);
+			var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+			var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
 
 			expect(feedbackString).to.equal(day + ' at ' + time);
 		});
@@ -32,7 +26,7 @@ describe('formatfuzzydate', function() {
 			it('should return "1 minute ago" if feedback posted ' + seconds + ' seconds before now', function() {
 				var date = new Date();
 				date.setSeconds(date.getSeconds() - seconds);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('1 minute ago');
 			});
 		});
@@ -41,7 +35,7 @@ describe('formatfuzzydate', function() {
 			it('should return "2 minutes ago" if feedback posted ' + seconds + ' seconds before now', function() {
 				var date = new Date();
 				date.setSeconds(date.getSeconds() - seconds);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('2 minutes ago');
 			});
 		});
@@ -50,7 +44,7 @@ describe('formatfuzzydate', function() {
 			it('should return "x minutes ago" if feedback posted ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal(`${minutes} minutes ago`);
 			});
 		});
@@ -59,7 +53,7 @@ describe('formatfuzzydate', function() {
 			it('should return "1 hour ago" if feedback posted ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('1 hour ago');
 			});
 		});
@@ -68,7 +62,7 @@ describe('formatfuzzydate', function() {
 			it('should return "2 hours ago" if feedback posted ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('2 hours ago');
 			});
 		});
@@ -77,7 +71,7 @@ describe('formatfuzzydate', function() {
 			it('should return "x hours ago" if feedback posted ' + Math.round(minutes / 60) + ' hours before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.getDateString(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				var numHours = Math.round(minutes / 60);
 				expect(feedbackString).to.equal(`${numHours} hours ago`);
 			});
@@ -87,8 +81,8 @@ describe('formatfuzzydate', function() {
 			it('should contain "yesterday at" if feedback posted ' + hours + ' hours before now', function() {
 				var date = new Date();
 				date.setHours(date.getHours() - hours);
-				var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-				var feedbackString = component.getDateString(date);
+				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = component.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('Yesterday at ' + time);
 			});
 		});
@@ -96,9 +90,9 @@ describe('formatfuzzydate', function() {
 		it('should contain "[day short] at [time]" if feedback posted 2 days before now', function() {
 			var date = new Date();
 			date.setDate(date.getDate() - 2);
-			var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-			var day = new DateTimeFormat('en-US', { weekday: 'short' }).format(date);
-			var feedbackString = component.getDateString(date);
+			var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+			var day = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(date);
+			var feedbackString = component.formatFuzzyDate(date);
 			expect(feedbackString).to.equal(day + ' at ' + time);
 		});
 
@@ -106,9 +100,9 @@ describe('formatfuzzydate', function() {
 			it('should contain "[month] [day] at [time]" if feedback posted ' + days + ' days before now', function() {
 				var date = new Date();
 				date.setDate(date.getDate() - days);
-				var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-				var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
-				var feedbackString = component.getDateString(date);
+				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
+				var feedbackString = component.formatFuzzyDate(date);
 
 				var dateNow = new Date();
 				if (date.getYear() === dateNow.getYear()) {
@@ -121,8 +115,8 @@ describe('formatfuzzydate', function() {
 			it('should contain full date string if feedback posted ' + days + ' days before now in the previous year', function() {
 				var date = new Date();
 				date.setDate(date.getDate() - days);
-				var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(date);
-				var feedbackString = component.getDateString(date);
+				var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = component.formatFuzzyDate(date);
 
 				expect(feedbackString).to.equal(day);
 			});

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -3,19 +3,19 @@ import DateTimeFormat from '../../src/date-time/format.js';
 var expect = chai.expect;
 
 describe('DateTimeFormat', function() {
-	var component = new DateTimeFormat('en-US');
+	var formatter = new DateTimeFormat('en-US');
 
 	describe('formatFuzzyDate', function() {
-		it('should return "just now" if feedback posted recently', function() {
+		it('should return "just now" if date is recent', function() {
 			var date = new Date();
-			var feedbackString = component.formatFuzzyDate(date);
+			var feedbackString = formatter.formatFuzzyDate(date);
 			expect(feedbackString).to.equal('Just now');
 		});
 
-		it('should return date time if feedback posted in the future', function() {
+		it('should return date time if date is in the future', function() {
 			var date = new Date();
 			date.setSeconds(date.getSeconds() + 60);
-			var feedbackString = component.formatFuzzyDate(date);
+			var feedbackString = formatter.formatFuzzyDate(date);
 			var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
 			var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
 
@@ -23,86 +23,86 @@ describe('DateTimeFormat', function() {
 		});
 
 		[31, 60, 89].forEach(function(seconds) {
-			it('should return "1 minute ago" if feedback posted ' + seconds + ' seconds before now', function() {
+			it('should return "1 minute ago" if date is ' + seconds + ' seconds before now', function() {
 				var date = new Date();
 				date.setSeconds(date.getSeconds() - seconds);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('1 minute ago');
 			});
 		});
 
 		[90, 120, 149].forEach(function(seconds) {
-			it('should return "2 minutes ago" if feedback posted ' + seconds + ' seconds before now', function() {
+			it('should return "2 minutes ago" if date is ' + seconds + ' seconds before now', function() {
 				var date = new Date();
 				date.setSeconds(date.getSeconds() - seconds);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('2 minutes ago');
 			});
 		});
 
 		[3, 5, 44].forEach(function(minutes) {
-			it('should return "x minutes ago" if feedback posted ' + minutes + ' minutes before now', function() {
+			it('should return "x minutes ago" if date is ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal(`${minutes} minutes ago`);
 			});
 		});
 
 		[45, 60, 89].forEach(function(minutes) {
-			it('should return "1 hour ago" if feedback posted ' + minutes + ' minutes before now', function() {
+			it('should return "1 hour ago" if date is ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('1 hour ago');
 			});
 		});
 
 		[90, 120, 149].forEach(function(minutes) {
-			it('should return "2 hours ago" if feedback posted ' + minutes + ' minutes before now', function() {
+			it('should return "2 hours ago" if date is ' + minutes + ' minutes before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('2 hours ago');
 			});
 		});
 
 		[150, 3 * 60, 24 * 60 - 1].forEach(function(minutes) {
-			it('should return "x hours ago" if feedback posted ' + Math.round(minutes / 60) + ' hours before now', function() {
+			it('should return "x hours ago" if date is ' + Math.round(minutes / 60) + ' hours before now', function() {
 				var date = new Date();
 				date.setMinutes(date.getMinutes() - minutes);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				var numHours = Math.round(minutes / 60);
 				expect(feedbackString).to.equal(`${numHours} hours ago`);
 			});
 		});
 
 		[24, 26, 47].forEach(function(hours) {
-			it('should contain "yesterday at" if feedback posted ' + hours + ' hours before now', function() {
+			it('should contain "yesterday at" if date is ' + hours + ' hours before now', function() {
 				var date = new Date();
 				date.setHours(date.getHours() - hours);
 				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 				expect(feedbackString).to.equal('Yesterday at ' + time);
 			});
 		});
 
-		it('should contain "[day short] at [time]" if feedback posted 2 days before now', function() {
+		it('should contain "[day short] at [time]" if date is 2 days before now', function() {
 			var date = new Date();
 			date.setDate(date.getDate() - 2);
 			var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
 			var day = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(date);
-			var feedbackString = component.formatFuzzyDate(date);
+			var feedbackString = formatter.formatFuzzyDate(date);
 			expect(feedbackString).to.equal(day + ' at ' + time);
 		});
 
 		[3, 32, 363].forEach(function(days) {
-			it('should contain "[month] [day] at [time]" if feedback posted ' + days + ' days before now', function() {
+			it('should contain "[month] [day] at [time]" if date is ' + days + ' days before now', function() {
 				var date = new Date();
 				date.setDate(date.getDate() - days);
 				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
 				var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 
 				var dateNow = new Date();
 				if (date.getYear() === dateNow.getYear()) {
@@ -112,11 +112,11 @@ describe('DateTimeFormat', function() {
 		});
 
 		[366].forEach(function(days) {
-			it('should contain full date string if feedback posted ' + days + ' days before now in the previous year', function() {
+			it('should contain full date string if date is ' + days + ' days before now in the previous year', function() {
 				var date = new Date();
 				date.setDate(date.getDate() - days);
 				var day = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(date);
-				var feedbackString = component.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date);
 
 				expect(feedbackString).to.equal(day);
 			});

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -87,6 +87,7 @@ describe('DateTimeFormat', function() {
 				expect(feedbackString).to.equal('Yesterday at ' + time);
 			});
 		});
+
 		[{ timeZone: 'America/Toronto', shortTimezone: 'EDT' },
 			{ timeZone: 'America/Vancouver', shortTimezone: 'PDT' },
 			{ timeZone: 'America/Winnipeg', shortTimezone: 'CDT' }].forEach(function(tz) {
@@ -96,7 +97,7 @@ describe('DateTimeFormat', function() {
 					var now = new Date(date);
 					date.setUTCHours(date.getUTCHours() - hours);
 					var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric', timeZone: tz.timeZone }).format(date);
-					var timeZoneFormatter = new DateTimeFormat('en-us', { timeZone: tz.timeZone });
+					var timeZoneFormatter = new DateTimeFormat('en-us', { timezoneidentifier: tz.timeZone });
 					var feedbackString = timeZoneFormatter.formatFuzzyDate(date, now);
 					expect(feedbackString).to.equal('Yesterday at ' + time);
 				});

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -79,7 +79,7 @@ describe('DateTimeFormat', function() {
 
 		[24, 26, 47].forEach(function(hours) {
 			it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before now', function() {
-				var date = new Date('March 20, 2019 23:59:59 CDT');
+				var date = new Date('March 20, 2019 23:59:59');
 				var now = new Date(date);
 				date.setHours(date.getHours() - hours);
 				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
@@ -90,7 +90,7 @@ describe('DateTimeFormat', function() {
 
 		[24, 26, 47].forEach(function(hours) {
 			it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before begining of month', function() {
-				var date = new Date('March 1, 2019 23:59:59 CST');
+				var date = new Date('March 1, 2019 23:59:59');
 				var now = new Date(date);
 				date.setHours(date.getHours() - hours);
 				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
@@ -99,9 +99,10 @@ describe('DateTimeFormat', function() {
 			});
 		});
 
+
 		[25, 26, 47].forEach(function(hours) {
 			it('should contain "[day short] at [time]" if calendar day is more than 1 from today', function() {
-				var date = new Date('March 20, 2019 00:00:00 CDT');
+				var date = new Date('March 20, 2019 00:00:00');
 				var now = new Date(date);
 				date.setHours(date.getHours() - hours);
 				var day = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(date);

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -1,0 +1,131 @@
+import FuzzyDate from '../../src/date-time/format-fuzzy-date';
+import DateTimeFormat from '../../src/date-time/format';
+import en from '../../src/locale-data/en';
+
+var expect = chai.expect;
+
+describe('formatfuzzydate', function() {
+	var component;
+
+	beforeEach(function() {
+		component = new FuzzyDate(en, 'en');
+	});
+
+	describe('getDateString', function() {
+		it('should return "just now" if feedback posted recently', function() {
+			var date = new Date();
+			var feedbackString = component.getDateString(date);
+			expect(feedbackString).to.equal('Just now');
+		});
+
+		it('should return date time if feedback posted in the future', function() {
+			var date = new Date();
+			date.setSeconds(date.getSeconds() + 60);
+			var feedbackString = component.getDateString(date);
+			var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+			var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
+
+			expect(feedbackString).to.equal(day + ' at ' + time);
+		});
+
+		[31, 60, 89].forEach(function(seconds) {
+			it('should return "1 minute ago" if feedback posted ' + seconds + ' seconds before now', function() {
+				var date = new Date();
+				date.setSeconds(date.getSeconds() - seconds);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal('1 minute ago');
+			});
+		});
+
+		[90, 120, 149].forEach(function(seconds) {
+			it('should return "2 minutes ago" if feedback posted ' + seconds + ' seconds before now', function() {
+				var date = new Date();
+				date.setSeconds(date.getSeconds() - seconds);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal('2 minutes ago');
+			});
+		});
+
+		[3, 5, 44].forEach(function(minutes) {
+			it('should return "x minutes ago" if feedback posted ' + minutes + ' minutes before now', function() {
+				var date = new Date();
+				date.setMinutes(date.getMinutes() - minutes);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal(`${minutes} minutes ago`);
+			});
+		});
+
+		[45, 60, 89].forEach(function(minutes) {
+			it('should return "1 hour ago" if feedback posted ' + minutes + ' minutes before now', function() {
+				var date = new Date();
+				date.setMinutes(date.getMinutes() - minutes);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal('1 hour ago');
+			});
+		});
+
+		[90, 120, 149].forEach(function(minutes) {
+			it('should return "2 hours ago" if feedback posted ' + minutes + ' minutes before now', function() {
+				var date = new Date();
+				date.setMinutes(date.getMinutes() - minutes);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal('2 hours ago');
+			});
+		});
+
+		[150, 3 * 60, 24 * 60 - 1].forEach(function(minutes) {
+			it('should return "x hours ago" if feedback posted ' + Math.round(minutes / 60) + ' hours before now', function() {
+				var date = new Date();
+				date.setMinutes(date.getMinutes() - minutes);
+				var feedbackString = component.getDateString(date);
+				var numHours = Math.round(minutes / 60);
+				expect(feedbackString).to.equal(`${numHours} hours ago`);
+			});
+		});
+
+		[24, 26, 47].forEach(function(hours) {
+			it('should contain "yesterday at" if feedback posted ' + hours + ' hours before now', function() {
+				var date = new Date();
+				date.setHours(date.getHours() - hours);
+				var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = component.getDateString(date);
+				expect(feedbackString).to.equal('Yesterday at ' + time);
+			});
+		});
+
+		it('should contain "[day short] at [time]" if feedback posted 2 days before now', function() {
+			var date = new Date();
+			date.setDate(date.getDate() - 2);
+			var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+			var day = new DateTimeFormat('en-US', { weekday: 'short' }).format(date);
+			var feedbackString = component.getDateString(date);
+			expect(feedbackString).to.equal(day + ' at ' + time);
+		});
+
+		[3, 32, 363].forEach(function(days) {
+			it('should contain "[month] [day] at [time]" if feedback posted ' + days + ' days before now', function() {
+				var date = new Date();
+				date.setDate(date.getDate() - days);
+				var time = new DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(date);
+				var feedbackString = component.getDateString(date);
+
+				var dateNow = new Date();
+				if (date.getYear() === dateNow.getYear()) {
+					expect(feedbackString).to.equal(day + ' at ' + time);
+				}
+			});
+		});
+
+		[366].forEach(function(days) {
+			it('should contain full date string if feedback posted ' + days + ' days before now in the previous year', function() {
+				var date = new Date();
+				date.setDate(date.getDate() - days);
+				var day = new DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = component.getDateString(date);
+
+				expect(feedbackString).to.equal(day);
+			});
+		});
+	});
+});

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -87,6 +87,18 @@ describe('DateTimeFormat', function() {
 				expect(feedbackString).to.equal('Yesterday at ' + time);
 			});
 		});
+
+		[24, 26, 47].forEach(function(hours) {
+			it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before begining of month', function() {
+				var date = new Date('March 1, 2019 23:59:59 CST');
+				var now = new Date(date);
+				date.setHours(date.getHours() - hours);
+				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = formatter.formatFuzzyDate(date, now);
+				expect(feedbackString).to.equal('Yesterday at ' + time);
+			});
+		});
+
 		[25, 26, 47].forEach(function(hours) {
 			it('should contain "[day short] at [time]" if calendar day is more than 1 from today', function() {
 				var date = new Date('March 20, 2019 00:00:00 CDT');

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -78,12 +78,24 @@ describe('DateTimeFormat', function() {
 		});
 
 		[24, 26, 47].forEach(function(hours) {
-			it('should contain "yesterday at" if date is ' + hours + ' hours before now', function() {
-				var date = new Date();
+			it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before now', function() {
+				var date = new Date('March 20, 2019 23:59:59 CDT');
+				var now = new Date(date);
 				date.setHours(date.getHours() - hours);
 				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
-				var feedbackString = formatter.formatFuzzyDate(date);
+				var feedbackString = formatter.formatFuzzyDate(date, now);
 				expect(feedbackString).to.equal('Yesterday at ' + time);
+			});
+		});
+		[25, 26, 47].forEach(function(hours) {
+			it('should contain "[day short] at [time]" if calendar day is more than 1 from today', function() {
+				var date = new Date('March 20, 2019 00:00:00 CDT');
+				var now = new Date(date);
+				date.setHours(date.getHours() - hours);
+				var day = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(date);
+				var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric' }).format(date);
+				var feedbackString = formatter.formatFuzzyDate(date, now);
+				expect(feedbackString).to.equal(day + ' at ' + time);
 			});
 		});
 

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -91,7 +91,7 @@ describe('DateTimeFormat', function() {
 			{ timeZone: 'America/Vancouver', shortTimezone: 'PDT' },
 			{ timeZone: 'America/Winnipeg', shortTimezone: 'CDT' }].forEach(function(tz) {
 			[24, 26, 47].forEach(function(hours) {
-				it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before now configuredTimeZone '+ tz.timeZone, function () {
+				it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before now configuredTimeZone ' + tz.timeZone, function() {
 					var date = new Date('March 20, 2019 23:59:59 ' + tz.shortTimezone);
 					var now = new Date(date);
 					date.setUTCHours(date.getUTCHours() - hours);

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -99,7 +99,6 @@ describe('DateTimeFormat', function() {
 			});
 		});
 
-
 		[25, 26, 47].forEach(function(hours) {
 			it('should contain "[day short] at [time]" if calendar day is more than 1 from today', function() {
 				var date = new Date('March 20, 2019 00:00:00');

--- a/test/date-time/format-fuzzy-date.js
+++ b/test/date-time/format-fuzzy-date.js
@@ -87,6 +87,21 @@ describe('DateTimeFormat', function() {
 				expect(feedbackString).to.equal('Yesterday at ' + time);
 			});
 		});
+		[{ timeZone: 'America/Toronto', shortTimezone: 'EDT' },
+			{ timeZone: 'America/Vancouver', shortTimezone: 'PDT' },
+			{ timeZone: 'America/Winnipeg', shortTimezone: 'CDT' }].forEach(function(tz) {
+			[24, 26, 47].forEach(function(hours) {
+				it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before now configuredTimeZone '+ tz.timeZone, function () {
+					var date = new Date('March 20, 2019 23:59:59 ' + tz.shortTimezone);
+					var now = new Date(date);
+					date.setUTCHours(date.getUTCHours() - hours);
+					var time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: 'numeric', timeZone: tz.timeZone }).format(date);
+					var timeZoneFormatter = new DateTimeFormat('en-us', { timeZone: tz.timeZone });
+					var feedbackString = timeZoneFormatter.formatFuzzyDate(date, now);
+					expect(feedbackString).to.equal('Yesterday at ' + time);
+				});
+			});
+		});
 
 		[24, 26, 47].forEach(function(hours) {
 			it('should contain "yesterday at" if date with time 23:59:59 ' + hours + ' hours before begining of month', function() {

--- a/test/date-time/format.js
+++ b/test/date-time/format.js
@@ -22,7 +22,6 @@ describe('DateTimeFormat', function() {
 			{format: 'shortDayOfWeek', expect: 'Mon'},
 			{format: 'longMonth', expect: 'August'},
 			{format: 'shortMonth', expect: 'Aug'},
-			{format: 'fuzzy', expect: 'August 3, 2015, 1:44 PM'}
 		].forEach(function(input) {
 			it('should apply locale format "' + input.format + '"', function() {
 				var dtFormat = new DateTimeFormat('en-US', {format: input.format, timezone: 'EST'});
@@ -32,10 +31,11 @@ describe('DateTimeFormat', function() {
 		});
 
 		[
-			{date: () => new Date(), expect: 'Just now'}
+			{date: () => new Date(), expect: 'Just now'},
+			{date: () => new Date('August 3, 2015, 1:44 PM EDT'),  expect: 'August 3, 2015, 1:44 PM'}
 		].forEach(function(input) {
 			it('should apply fuzzy format', function() {
-				var dtFormat = new DateTimeFormat('en-US', {format: 'fuzzy'});
+				var dtFormat = new DateTimeFormat('en-US', {format: 'fuzzy', timezoneidentifier: 'America/Toronto'});
 				var value = dtFormat.format(input.date());
 				expect(value).to.equal(input.expect);
 			});

--- a/test/date-time/format.js
+++ b/test/date-time/format.js
@@ -21,11 +21,22 @@ describe('DateTimeFormat', function() {
 			{format: 'longDayOfWeek', expect: 'Monday'},
 			{format: 'shortDayOfWeek', expect: 'Mon'},
 			{format: 'longMonth', expect: 'August'},
-			{format: 'shortMonth', expect: 'Aug'}
+			{format: 'shortMonth', expect: 'Aug'},
+			{format: 'fuzzy', expect: 'August 3, 2015, 1:44 PM'}
 		].forEach(function(input) {
 			it('should apply locale format "' + input.format + '"', function() {
 				var dtFormat = new DateTimeFormat('en-US', {format: input.format, timezone: 'EST'});
 				var value = dtFormat.format(new Date(2015, 7, 3, 13, 44));
+				expect(value).to.equal(input.expect);
+			});
+		});
+
+		[
+			{date: () => new Date(), expect: 'Just now'}
+		].forEach(function(input) {
+			it('should apply fuzzy format', function() {
+				var dtFormat = new DateTimeFormat('en-US', {format: 'fuzzy'});
+				var value = dtFormat.format(input.date());
 				expect(value).to.equal(input.expect);
 			});
 		});

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
 		<script type="module" src="localeProvider.js"></script>
 		<script type="module" src="calendar/gregorian.js"></script>
 		<script type="module" src="date-time/format-date.js"></script>
+		<script type="module" src="date-time/format-fuzzy-date.js"></script>
 		<script type="module" src="date-time/format-time.js"></script>
 		<script type="module" src="date-time/format.js"></script>
 		<script type="module" src="date-time/parse-date.js"></script>


### PR DESCRIPTION
Adapted from https://github.com/Brightspace/d2l-activity-details-ui/blob/3d616ea18b625f7eec60cc3b0a592ad538e9d180/src/behaviors/fuzzy-date-behavior.js to implement fuzzy dates for more general consumption.

The contents of this PR allow for the following usages like:
```
> const format = require('./dist/date-time/format');
> new format('en', {format:'fuzzy'}).format(new Date())
'Just now'
> new format('en', {format:'fuzzy'}).format(new Date('March 21, 2019 7:38 am'))
'1 minute ago'
> new format('en', {format:'fuzzy'}).format(new Date('March 21, 2019 7:37 am'))
'2 minutes ago'
> new format('en', {format:'fuzzy'}).format(new Date('March 21, 2019 7:34 am'))
'5 minutes ago'
> new format('en', {format:'fuzzy'}).format(new Date('March 21, 2019 6:38 am'))
'1 hour ago'
> new format('en', {format:'fuzzy'}).format(new Date('March 21, 2019 5:38 am'))
'2 hours ago'
```

Tests run in both Chrome 72 and Firefox 66.  Still need to verify in IE 11 and Edge (Mocha doesn't seem to run in either)